### PR TITLE
FEMR 275 bug displays 0'0" instead of N/A

### DIFF
--- a/app/femr/ui/views/partials/helpers/outputHeightOrNA.scala.html
+++ b/app/femr/ui/views/partials/helpers/outputHeightOrNA.scala.html
@@ -9,7 +9,12 @@
              * Hack to do it on a string using String.Format() *@
             @("%s.%2sm".format(feet, inches).replace(' ', '0'))
         }
+    } else  {
+    @* Output empty value if feet and inches are equal to "0" string  or values are null *@
+    @if((inches == null && feet == null) || (inches.equals("0") && feet.equals("0"))) {
+        @emptyValue
     } else {
+
         @if(feet != null && !feet.equals("null")) {
             @* Truncate feet at period so feet is a whole value *@
             @feet.replaceAll("\\..*", "")'
@@ -18,10 +23,5 @@
             @* Truncate inches at period so inches is a whole value *@
             @inches.replaceAll("\\..*", "")"
         }
-
-        @* Output empty value if feet and inches are equal to "null" string *@
-        @if((inches != null && feet != null) && (inches.equals("null") && feet.equals("null"))) {
-            @emptyValue
-        }
     }
-
+}


### PR DESCRIPTION
Added and altered a conditional to check for the value 0 so that N/A would be displayed in lieu of 0'0" in the height field for the encounter page whenever no value was entered by the user.